### PR TITLE
Properly grab the file name

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = function(content) {
     var options = loaderUtils.parseQuery(this.query);
     var manifest = require(path.join(options.outputDir, options.manifest));
     var relativeSplit = options.relativeSplit || '/';
-    var fileName = this.resourcePath.split(relativeSplit)[1] || '';
+    var fileName = this.resourcePath.split(relativeSplit).slice(-1) || '';
     var prefix = options.prefix || '';
     var result = manifest[fileName] ? prefix + '/' + manifest[fileName] : '';
 


### PR DESCRIPTION
Right now if you don't pass `relativeSplit` option the URL will be split at `/` & `fileName` will become equal to `User` 

We always want to grab the last item in form `this.resourcePath.split(relativeSplit)` to grab the proper filename so this PR fixes this bug.
